### PR TITLE
Re-enable A2S_RULES queries on CS:GO

### DIFF
--- a/amstats/query.go
+++ b/amstats/query.go
@@ -94,12 +94,6 @@ func queryServer(addr *net.TCPAddr) (*Server, error) {
 		return nil, err
 	}
 
-	// We can't query rules for CSGO servers anymore because Valve.
-	csgo := (info.Ext != nil && info.Ext.AppId == valve.App_CSGO)
-	if csgo {
-		return nil, nil
-	}
-
 	rules, err := query.QueryRules()
 	if err != nil {
 		return nil, err

--- a/blaster.go
+++ b/blaster.go
@@ -254,9 +254,7 @@ func main() {
 			out.SpecTvName = info.SpecTv.Name
 		}
 
-		// We can't query rules for CSGO servers anymore because Valve.
-		csgo := (info.Ext != nil && info.Ext.AppId == valve.App_CSGO)
-		if !csgo && !*flag_norules {
+		if !*flag_norules {
 			rules, err := query.QueryRules()
 			if err != nil {
 				out.Rules = map[string]string{

--- a/valve/packet.go
+++ b/valve/packet.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-const kMaxPacketSize = 1400
+const kMaxPacketSize = 5000
 
 var ErrOutOfBounds = errors.New("read out of bounds")
 


### PR DESCRIPTION
With the [A2S_RULES fix](https://github.com/alliedmodders/sourcemod/pull/614) in stable SourceMod builds now, CS:GO SM servers can now handle rules queries again.