### PR TITLE
Exit if the master server is nil

### DIFF
--- a/blaster.go
+++ b/blaster.go
@@ -192,6 +192,7 @@ func main() {
 	master, err := valve.NewMasterServerQuerier(*flag_master)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not query master: %s", err.Error())
+		os.Exit(1)
 	}
 	defer master.Close()
 


### PR DESCRIPTION
If it would error on line 192, the master server would be set to nil and the application would crash.